### PR TITLE
Fix and more

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "type": "replugged-plugin",
   "renderer": "src/index.tsx",
+  "plaintextPatches": "src/plaintextPatches.ts",
   "source": "https://github.com/asportnoy/member-count",
   "image": "https://i.imgur.com/92WcfnA.pngg"
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import { Injector, Logger, common, components, settings, webpack } from "replugged";
-import { GuildTooltip, ListThin } from "./types";
+import { GuildTooltip } from "./types";
 import MemberCount from "./MemberCount";
 
 const { lodash: _ } = common;
@@ -26,16 +26,12 @@ export const cfg = await settings.init<Settings, keyof typeof defaultSettings>(
 );
 
 async function patchGuildTooltip(): Promise<void> {
-  const tooltipMod = await webpack.waitForModule<Record<string, GuildTooltip>>(
-    webpack.filters.bySource("Messages.GUILD_JOIN_REQUEST_STATUS_TOOLTIP_STARTED"),
-  );
-  const key = webpack.getFunctionKeyBySource(tooltipMod, "includeActivity:");
-  if (!key) {
-    logger.error("Failed to find guild tooltip key");
-    return;
-  }
+  const tooltipMod = await webpack.waitForProps<{
+    default: GuildTooltip;
+    GuildTooltipText: () => unknown;
+  }>("GuildTooltipText", "default");
 
-  inject.after(tooltipMod, key, ([{ disabled, guild }], res) => {
+  inject.after(tooltipMod, "default", ([{ disabled, guild }], res) => {
     if (!cfg.get("showInGuildTooltip")) return;
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (disabled || !guild) return;
@@ -58,50 +54,36 @@ async function patchGuildTooltip(): Promise<void> {
   });
 }
 
-async function patchMemberList(): Promise<void> {
-  const listMod = await webpack.waitForProps<{
-    ListThin: ListThin;
-  }>("ListThin");
-
-  inject.after(listMod.ListThin, "render", ([args], res) => {
-    if (!cfg.get("showInMemberList")) return;
-    const isChannel = args["data-list-id"]?.startsWith("members-");
-    const isThread = !isChannel && args.className?.startsWith("members-");
-
-    if (!isChannel && !isThread) return;
-
-    const children = _.get(
-      res.props,
-      isThread ? "children.0.props.children.props.children" : "children",
-    );
-    if (!children || !Array.isArray(children)) {
-      logger.error("Failed to find children", { props: res.props, children, isThread });
-      return;
-    }
-
-    children.unshift(
-      <>
-        <ErrorBoundary fallback={<></>}>
-          <Flex
-            direction={Flex.Direction.VERTICAL}
-            align={Flex.Align.CENTER}
-            style={{
-              marginTop: "20px",
-              gap: "4px",
-            }}>
-            <MemberCount compact={false} />
-          </Flex>
-        </ErrorBoundary>
-      </>,
-    );
-  });
-}
-
 export function start(): void {
-  void patchMemberList();
   void patchGuildTooltip();
 }
 
 export function stop(): void {
   inject.uninjectAll();
+}
+
+export function _patchMemberList(args: {
+  channel?: { isThread: () => boolean };
+}): React.ReactElement | void {
+  if (!cfg.get("showInMemberList")) return;
+
+  const isThread = args.channel?.isThread();
+
+  if (!args.channel && !isThread) return;
+
+  return (
+    <>
+      <ErrorBoundary fallback={<></>}>
+        <Flex
+          direction={Flex.Direction.VERTICAL}
+          align={Flex.Align.CENTER}
+          style={{
+            marginTop: "20px",
+            gap: "4px",
+          }}>
+          <MemberCount compact={false} />
+        </Flex>
+      </ErrorBoundary>
+    </>
+  );
 }

--- a/src/plaintextPatches.ts
+++ b/src/plaintextPatches.ts
@@ -4,7 +4,7 @@ export default [
     find: ".AnalyticsSections.MEMBER_LIST",
     replacements: [
       {
-        match: /(navigator:\w+,children:)(.+?listRef:\w+}\))/,
+        match: /(navigator:\w+,children:)(.+?updateMaxContentFeedRowSeen:\w+}\))/,
         replace: (_: string, prefix: string, children: string) =>
           `${prefix}[replugged.plugins.getExports("dev.albertp.MemberCount")._patchMemberList(arguments[0]),${children}]`,
       },

--- a/src/plaintextPatches.ts
+++ b/src/plaintextPatches.ts
@@ -1,0 +1,13 @@
+import { PlaintextPatch } from "replugged/dist/types";
+export default [
+  {
+    find: ".AnalyticsSections.MEMBER_LIST",
+    replacements: [
+      {
+        match: /(navigator:\w+,children:)(.+?listRef:\w+}\))/,
+        replace: (_: string, prefix: string, children: string) =>
+          `${prefix}[replugged.plugins.getExports("dev.albertp.MemberCount")._patchMemberList(arguments[0]),${children}]`,
+      },
+    ],
+  },
+] as PlaintextPatch[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,4 @@ export interface SelectedChannelStore extends Store {
   getChannelId: () => string | null;
 }
 
-export interface ListThin {
-  render: (args: { className?: string; "data-list-id"?: string }) => React.ReactElement;
-}
-
 export type GuildTooltip = (args: { disabled: boolean; guild: Guild }) => React.ReactNode;


### PR DESCRIPTION
fixes the patch for guild tooltip and transfers the patch for member list to plain text patch so that it would patch only member list instead of every scrollable list like channels, dms, etc.